### PR TITLE
RDK-56621: Update all the power manager plugin clients to new register events

### DIFF
--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -190,6 +190,7 @@ namespace WPEFramework
         {
             _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
+                                      .withRetry(25)
                                       .createInterface();
             registerEventHandlers();
         }
@@ -201,6 +202,9 @@ namespace WPEFramework
             if(!_registeredEventHandlers && _powerManagerPlugin) {
                 _registeredEventHandlers = true;
                 _powerManagerPlugin->Register(&_pwrMgrNotification);
+                _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::INotification>());
+                _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModePreChangeNotification>());
+                _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
             }
         }
 

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -190,7 +190,8 @@ namespace WPEFramework
         {
             _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
-                                      .withRetry(25)
+                                      .withRetryIntervalMS(200)
+                                      .withRetryCount(25)
                                       .createInterface();
             registerEventHandlers();
         }

--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -201,9 +201,6 @@ namespace WPEFramework
 
             if(!_registeredEventHandlers && _powerManagerPlugin) {
                 _registeredEventHandlers = true;
-                _powerManagerPlugin->Register(&_pwrMgrNotification);
-                _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::INotification>());
-                _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModePreChangeNotification>());
                 _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
             }
         }

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -111,7 +111,9 @@ namespace WPEFramework
             static MiracastController *m_miracast_ctrler_obj;
 
         private:
-            class PowerManagerNotification : public Exchange::IPowerManager::INotification {
+            class PowerManagerNotification : public Exchange::IPowerManager::INotification,
+                                                     public Exchange::IPowerManager::IModePreChangeNotification,
+                                                     public Exchange::IPowerManager::IModeChangedNotification {
             private:
                 PowerManagerNotification(const PowerManagerNotification&) = delete;
                 PowerManagerNotification& operator=(const PowerManagerNotification&) = delete;
@@ -134,8 +136,17 @@ namespace WPEFramework
                 void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override {}
                 void OnRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor) override {}
 
+                template <typename INTERFACE>
+                T* baseInterface()
+                {
+                    static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                    return static_cast<T*>(this);
+                }
+
                 BEGIN_INTERFACE_MAP(PowerManagerNotification)
                 INTERFACE_ENTRY(Exchange::IPowerManager::INotification)
+                INTERFACE_ENTRY(Exchange::IPowerManager::IModePreChangeNotification)
+                INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
                 END_INTERFACE_MAP
             
             private:

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -129,7 +129,7 @@ namespace WPEFramework
                     _parent.onPowerModeChanged(currentState, newState);
                 }
 
-                template <typename INTERFACE>
+                template <typename T>
                 T* baseInterface()
                 {
                     static_assert(std::is_base_of<T, Notification>(), "base type mismatch");

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -132,7 +132,7 @@ namespace WPEFramework
                 template <typename T>
                 T* baseInterface()
                 {
-                    static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                    static_assert(std::is_base_of<T, PowerManagerNotification>(), "base type mismatch");
                     return static_cast<T*>(this);
                 }
 

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -111,9 +111,7 @@ namespace WPEFramework
             static MiracastController *m_miracast_ctrler_obj;
 
         private:
-            class PowerManagerNotification : public Exchange::IPowerManager::INotification,
-                                                     public Exchange::IPowerManager::IModePreChangeNotification,
-                                                     public Exchange::IPowerManager::IModeChangedNotification {
+            class PowerManagerNotification : public Exchange::IPowerManager::IModeChangedNotification {
             private:
                 PowerManagerNotification(const PowerManagerNotification&) = delete;
                 PowerManagerNotification& operator=(const PowerManagerNotification&) = delete;
@@ -130,11 +128,6 @@ namespace WPEFramework
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }
-                void OnPowerModePreChange(const PowerState &currentState, const PowerState &newState) override {}
-                void OnDeepSleepTimeout(const int &wakeupTimeout) override {}
-                void OnNetworkStandbyModeChanged(const bool &enabled) override {}
-                void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override {}
-                void OnRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor) override {}
 
                 template <typename INTERFACE>
                 T* baseInterface()
@@ -144,8 +137,6 @@ namespace WPEFramework
                 }
 
                 BEGIN_INTERFACE_MAP(PowerManagerNotification)
-                INTERFACE_ENTRY(Exchange::IPowerManager::INotification)
-                INTERFACE_ENTRY(Exchange::IPowerManager::IModePreChangeNotification)
                 INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
                 END_INTERFACE_MAP
             

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -173,7 +173,8 @@ void XCast::InitializePowerManager(PluginHost::IShell* service)
     LOGINFO("Connect the COM-RPC socket\n");
     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
         .withIShell(service)
-        .withRetry(25)
+        .withRetryIntervalMS(200)
+        .withRetryCount(25)
         .createInterface();
     registerEventHandlers();
 }

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -223,9 +223,7 @@ void XCast::registerEventHandlers()
 
     if(!_registeredEventHandlers && _powerManagerPlugin) {
         _registeredEventHandlers = true;
-        _powerManagerPlugin->Register(&_pwrMgrNotification);
-        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::INotification>());
-        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModePreChangeNotification>());
+        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::INetworkStandbyModeChangedNotification>());
         _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
     }
 }

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -173,6 +173,7 @@ void XCast::InitializePowerManager(PluginHost::IShell* service)
     LOGINFO("Connect the COM-RPC socket\n");
     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
         .withIShell(service)
+        .withRetry(25)
         .createInterface();
     registerEventHandlers();
 }
@@ -223,6 +224,9 @@ void XCast::registerEventHandlers()
     if(!_registeredEventHandlers && _powerManagerPlugin) {
         _registeredEventHandlers = true;
         _powerManagerPlugin->Register(&_pwrMgrNotification);
+        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::INotification>());
+        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModePreChangeNotification>());
+        _powerManagerPlugin->Register(_pwrMgrNotification.baseInterface<Exchange::IPowerManager::IModeChangedNotification>());
     }
 }
 

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -145,8 +145,7 @@ namespace Plugin {
         };
 
     private:
-        class PowerManagerNotification : public Exchange::IPowerManager::INotification,
-                                                     public Exchange::IPowerManager::IModePreChangeNotification,
+        class PowerManagerNotification : public Exchange::IPowerManager::INetworkStandbyModeChangedNotification,
                                                      public Exchange::IPowerManager::IModeChangedNotification {
         private:
             PowerManagerNotification(const PowerManagerNotification&) = delete;
@@ -164,14 +163,11 @@ namespace Plugin {
             {
                 _parent.onPowerModeChanged(currentState, newState);
             }
-            void OnPowerModePreChange(const PowerState &currentState, const PowerState &newState) override {}
-            void OnDeepSleepTimeout(const int &wakeupTimeout) override {}
+
             void OnNetworkStandbyModeChanged(const bool &enabled)
             {
                 _parent.onNetworkStandbyModeChanged(enabled);
             }
-            void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override {}
-            void OnRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor) override {}
 
             template <typename INTERFACE>
             T* baseInterface()
@@ -181,8 +177,7 @@ namespace Plugin {
             }
 
             BEGIN_INTERFACE_MAP(PowerManagerNotification)
-            INTERFACE_ENTRY(Exchange::IPowerManager::INotification)
-            INTERFACE_ENTRY(Exchange::IPowerManager::IModePreChangeNotification)
+            INTERFACE_ENTRY(Exchange::IPowerManager::INetworkStandbyModeChangedNotification)
             INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
             END_INTERFACE_MAP
 

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -172,7 +172,7 @@ namespace Plugin {
             template <typename T>
             T* baseInterface()
             {
-                static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                static_assert(std::is_base_of<T, PowerManagerNotification>(), "base type mismatch");
                 return static_cast<T*>(this);
             }
 

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -145,7 +145,9 @@ namespace Plugin {
         };
 
     private:
-        class PowerManagerNotification : public Exchange::IPowerManager::INotification {
+        class PowerManagerNotification : public Exchange::IPowerManager::INotification,
+                                                     public Exchange::IPowerManager::IModePreChangeNotification,
+                                                     public Exchange::IPowerManager::IModeChangedNotification {
         private:
             PowerManagerNotification(const PowerManagerNotification&) = delete;
             PowerManagerNotification& operator=(const PowerManagerNotification&) = delete;
@@ -171,8 +173,17 @@ namespace Plugin {
             void OnThermalModeChanged(const ThermalTemperature &currentThermalLevel, const ThermalTemperature &newThermalLevel, const float &currentTemperature) override {}
             void OnRebootBegin(const string &rebootReasonCustom, const string &rebootReasonOther, const string &rebootRequestor) override {}
 
+            template <typename INTERFACE>
+            T* baseInterface()
+            {
+                static_assert(std::is_base_of<T, Notification>(), "base type mismatch");
+                return static_cast<T*>(this);
+            }
+
             BEGIN_INTERFACE_MAP(PowerManagerNotification)
             INTERFACE_ENTRY(Exchange::IPowerManager::INotification)
+            INTERFACE_ENTRY(Exchange::IPowerManager::IModePreChangeNotification)
+            INTERFACE_ENTRY(Exchange::IPowerManager::IModeChangedNotification)
             END_INTERFACE_MAP
 
         private:

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -169,7 +169,7 @@ namespace Plugin {
                 _parent.onNetworkStandbyModeChanged(enabled);
             }
 
-            template <typename INTERFACE>
+            template <typename T>
             T* baseInterface()
             {
                 static_assert(std::is_base_of<T, Notification>(), "base type mismatch");

--- a/helpers/PluginInterfaceBuilder.h
+++ b/helpers/PluginInterfaceBuilder.h
@@ -101,6 +101,7 @@ namespace Plugin {
         WPEFramework::PluginHost::IShell* controller = builder.controller();
         const std::string& callsign = builder.callSign();
         const int retry_count = builder.retryCount();
+        const uint32_t retry_interval = builder.retryInterval();
         int count = 0;
 
         if (!controller) {
@@ -118,7 +119,7 @@ namespace Plugin {
             else
             {
                 count++;
-                usleep(200*1000);
+                usleep(retry_interval*1000);
             }
         }while(count < retry_count);
 
@@ -139,6 +140,7 @@ namespace Plugin {
         uint32_t _version;
         uint32_t _timeout;
         int _retry_count;
+        uint32_t _retry_interval;
 
     public:
         PluginInterfaceBuilder(const char* callsign)
@@ -147,6 +149,7 @@ namespace Plugin {
             , _version(static_cast<uint32_t>(~0))
             , _timeout(3000)
             ,_retry_count(0)
+            ,_retry_interval(0)
         {
         }
 
@@ -171,7 +174,13 @@ namespace Plugin {
             return *this;
         }
 
-        inline PluginInterfaceBuilder& withRetry(int retryCount)
+        inline PluginInterfaceBuilder& withRetryIntervalMS(int retryInterval)
+        {
+            _retry_interval = retryInterval;
+            return *this;
+        }
+
+        inline PluginInterfaceBuilder& withRetryCount(int retryCount)
         {
             _retry_count = retryCount;
             return *this;
@@ -187,6 +196,11 @@ namespace Plugin {
 
             // pass on the ownership of controller to interfaceRef
             return std::move(PluginInterfaceRef<INTERFACE>(interface, _service));
+        }
+
+        const uint32_t retryInterval() const
+        {
+            return _retry_interval;
         }
 
         const int retryCount() const

--- a/helpers/PluginInterfaceBuilder.h
+++ b/helpers/PluginInterfaceBuilder.h
@@ -114,11 +114,13 @@ namespace Plugin {
 
             if (pluginInterface) {
                 pluginInterface->AddRef();
+                LOGINFO("plugin interface succeed and retry count: %d",count);
                 return pluginInterface;
             }
             else
             {
                 count++;
+                LOGERR("plugin interface failed and retry: %d",count);
                 usleep(retry_interval*1000);
             }
         }while(count < retry_count);

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -135,7 +135,8 @@ namespace WPEFramework
                 {
                     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
-                                      .withRetry(25)
+                                      .withRetryIntervalMS(200)
+                                      .withRetryCount(25)
                                       .createInterface();
                 }
                 if (!s_instance)

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -135,6 +135,7 @@ namespace WPEFramework
                 {
                     _powerManagerPlugin = PowerManagerInterfaceBuilder(_T("org.rdk.PowerManager"))
                                       .withIShell(service)
+                                      .withRetry(25)
                                       .createInterface();
                 }
                 if (!s_instance)


### PR DESCRIPTION
RDK-56621: Update all the power manager plugin clients to new register events

Reason for changes: The PowerManager plugin's events are separated into different classes
Test procedure: Full stack build