### PR TITLE
RDK-57093: Update Plugin Clients to use update Power manager interface

### DIFF
--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -207,7 +207,7 @@ namespace WPEFramework
         }
 
 
-		void MiracastService:: onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+		void MiracastService:: onPowerModeChanged(const PowerState currentState, const PowerState newState)
 		{
 			if (nullptr == _instance)
 			{

--- a/Miracast/MiracastService/MiracastService.h
+++ b/Miracast/MiracastService/MiracastService.h
@@ -98,7 +98,7 @@ namespace WPEFramework
             virtual void onMiracastServiceClientConnectionError(string client_mac, string client_name , eMIRACAST_SERVICE_ERR_CODE error_code ) override;
             virtual void onMiracastServiceLaunchRequest(string src_dev_ip, string src_dev_mac, string src_dev_name, string sink_dev_ip, bool is_connect_req_reported ) override;
             virtual void onStateChange(eMIRA_SERVICE_STATES state ) override;
-            void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
+            void onPowerModeChanged(const PowerState currentState, const PowerState newState);
             void registerEventHandlers();
 
             BEGIN_INTERFACE_MAP(MiracastService)
@@ -124,7 +124,7 @@ namespace WPEFramework
                 ~PowerManagerNotification() override = default;
             
             public:
-                void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+                void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
                 {
                     _parent.onPowerModeChanged(currentState, newState);
                 }

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -271,7 +271,7 @@ bool XCast::setPowerState(std::string powerState)
     return ret;
 }
 
-void XCast::onPowerModeChanged(const PowerState &currentState, const PowerState &newState)
+void XCast::onPowerModeChanged(const PowerState currentState, const PowerState newState)
 {
     LOGINFO("onPowerModeChanged: State Changed %d -- > %d\r",
         currentState, newState);
@@ -281,7 +281,7 @@ void XCast::onPowerModeChanged(const PowerState &currentState, const PowerState 
     powerModeChangeThread.detach();
 }
 
-void XCast::onNetworkStandbyModeChanged(const bool &enabled)
+void XCast::onNetworkStandbyModeChanged(const bool enabled)
 {
     m_networkStandbyMode = enabled;
     LOGWARN("creating worker thread for threadNetworkStandbyModeChangeEvent Mode :%u",m_networkStandbyMode);

--- a/XCast/XCast.h
+++ b/XCast/XCast.h
@@ -64,8 +64,8 @@ namespace Plugin {
         XCast();
         virtual ~XCast();
         void registerEventHandlers();
-        void onPowerModeChanged(const PowerState &currentState, const PowerState &newState);
-        void onNetworkStandbyModeChanged(const bool &enabled);
+        void onPowerModeChanged(const PowerState currentState, const PowerState newState);
+        void onNetworkStandbyModeChanged(const bool enabled);
         virtual const string Initialize(PluginHost::IShell* service) override;
         virtual void Deinitialize(PluginHost::IShell* service) override;
         virtual string Information() const override { return {}; }
@@ -159,12 +159,12 @@ namespace Plugin {
             ~PowerManagerNotification() override = default;
 
         public:
-            void OnPowerModeChanged(const PowerState &currentState, const PowerState &newState) override
+            void OnPowerModeChanged(const PowerState currentState, const PowerState newState) override
             {
                 _parent.onPowerModeChanged(currentState, newState);
             }
 
-            void OnNetworkStandbyModeChanged(const bool &enabled)
+            void OnNetworkStandbyModeChanged(const bool enabled)
             {
                 _parent.onNetworkStandbyModeChanged(enabled);
             }


### PR DESCRIPTION
Reason for change: Interface API arguments should not be passed by reference if they are primitive data types.
Test Procedure: unit test 
Risks: LOW