### PR TITLE
RDK-57093: PowerManager Interface methods and event APIs modified

### DIFF
--- a/Miracast/MiracastService/MiracastService.cpp
+++ b/Miracast/MiracastService/MiracastService.cpp
@@ -167,7 +167,7 @@ namespace WPEFramework
 
         const void MiracastService::InitializePowerState()
         {
-            uint32_t res = Core::ERROR_GENERAL;
+            Core::hresult res = Core::ERROR_GENERAL;
             PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
             PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
 

--- a/XCast/XCast.cpp
+++ b/XCast/XCast.cpp
@@ -181,7 +181,7 @@ void XCast::InitializePowerManager(PluginHost::IShell* service)
 
 void XCast::InitializeIARM()
 {
-    uint32_t retStatus = Core::ERROR_GENERAL;
+    Core::hresult retStatus = Core::ERROR_GENERAL;
     PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
     PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
     bool nwStandby = false;
@@ -233,7 +233,7 @@ bool XCast::setPowerState(std::string powerState)
 {
     PowerState cur_powerState = m_powerState,
                new_powerState = WPEFramework::Exchange::IPowerManager::POWER_STATE_OFF;
-    uint32_t status = Core::ERROR_GENERAL;
+    Core::hresult status = Core::ERROR_GENERAL;
     bool ret = true;
     if ("ON" == powerState)
     {

--- a/helpers/frontpanel.cpp
+++ b/helpers/frontpanel.cpp
@@ -160,7 +160,7 @@ namespace WPEFramework
 
 #if defined(HAS_API_POWERSTATE)
                     {
-                        uint32_t res = Core::ERROR_GENERAL;
+                        Core::hresult res = Core::ERROR_GENERAL;
                         PowerState pwrStateCur = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         PowerState pwrStatePrev = WPEFramework::Exchange::IPowerManager::POWER_STATE_UNKNOWN;
                         ASSERT (_powerManagerPlugin);


### PR DESCRIPTION
RDK-57093: PowerManager Interface methods and event APIs modified

Reason for changes: The Interface method return type and event APIs are modified as per API spec
Test procedure: Full stack build
Risk: Low