### PR TITLE
RDKEMW-4136: Coverity integration with Entservices-casting repo

### DIFF
--- a/cov_build.sh
+++ b/cov_build.sh
@@ -31,6 +31,8 @@ cmake -G Ninja -S "$GITHUB_WORKSPACE" -B build/entservices-casting \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/rdk/iarmmgrs-hal \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/ccec/drivers \
 -I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/headers/network \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks \
+-I ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/thunder \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/devicesettings.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Iarm.h \
 -include ${GITHUB_WORKSPACE}/entservices-testframework/Tests/mocks/Rfc.h \


### PR DESCRIPTION
Reason for change: Coverity integration with middleware component workflow 
Test Procedure: Verify checks in Github
Risks: Low
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com