### PR TITLE
RDKEMW-4522: Use udhcpc.script from /etc/wifi_p2p Miracast P2P Client Mode

### DIFF
--- a/Miracast/MiracastService/MiracastController.cpp
+++ b/Miracast/MiracastService/MiracastController.cpp
@@ -272,7 +272,7 @@ std::string MiracastController::start_DHCPClient(std::string interface, std::str
 
     sprintf(command, "/sbin/udhcpc -v -i ");
     sprintf(command + strlen(command), "%s" , interface.c_str());
-    sprintf(command + strlen(command), " -s /etc/netsrvmgr/p2p_udhcpc.script 2>&1");
+    sprintf(command + strlen(command), " -s /etc/wifi_p2p/udhcpc.script 2>&1");
     MIRACASTLOG_VERBOSE("command : [%s]", command);
 
     while ( retry_count-- )


### PR DESCRIPTION
RDKEMW-4522: Use udhcpc.script from /etc/wifi_p2p Miracast P2P Client Mode

Reason for change: Earlier p2p_udhcpc script available in netsrvmgr which is deprecated. Hence moving it to here.
Test Procedure: Miracast should work in P2P client mode
Risks: None
Priority: P1

Signed-off-by: yuvaramachandran_gurusamy [yuvaramachandran_gurusamy@comcast.com]