### PR TITLE
RDKEMW-4708: Replacing IARM Power manager with Power Manager Plugin

### DIFF
--- a/helpers/PluginInterfaceBuilder.h
+++ b/helpers/PluginInterfaceBuilder.h
@@ -113,7 +113,6 @@ namespace Plugin {
             auto pluginInterface = controller->QueryInterfaceByCallsign<INTERFACE>(callsign.c_str());
 
             if (pluginInterface) {
-                pluginInterface->AddRef();
                 LOGINFO("plugin interface succeed and retry count: %d",count);
                 return pluginInterface;
             }


### PR DESCRIPTION
AddRef() is called within QueryInterface(). So, removed AddRef()